### PR TITLE
feat(mysql): allow to configure a custom port and use over ssh

### DIFF
--- a/bin/db-server
+++ b/bin/db-server
@@ -8,9 +8,10 @@ server="${2}"
 connectiontype="${3}"
 ssh="${4}"
 host="${5}"
-username="${6}"
-password="${7}"
-database="${8}"
+port="${6}"
+username="${7}"
+password="${8}"
+database="${9}"
 
 write_config()
 {
@@ -35,6 +36,7 @@ write_config()
   echo "user = ${username}" >> "${_credentials}"
   echo "password = ${password}" >> "${_credentials}"
   echo "host = ${host}" >> "${_credentials}"
+  echo "port = ${port}" >> "${_credentials}"
 
   chmod 600 "${_credentials}"
 
@@ -76,7 +78,7 @@ delete_config()
 add_server()
 {
   while true; do
-    if [ "$#" -ne 7 ]; then
+    if [ "$#" -ne 8 ]; then
 
       echo ""
       echo "${COLOR_LIGHT_BLUE}Please provide the connection details for the database${COLOR_NC}"
@@ -95,10 +97,14 @@ add_server()
           ssh=${answer}
           ;;
       esac
-      
+
       echo "Please provide the database host. For connection types SSH and direct, this is probably 127.0.0.1".
       user_input "Database host" "Please provide a database hostname" "127.0.0.1" 0
       host=${answer}
+
+      echo "Please provide the database port. For connection types SSH and direct, this is probably 3306".
+      user_input "Database port" "Please provide a database port" "3306" 0
+      port=${answer}
 
       user_input "Username" "Please provide a username" "root" 0
       username=${answer}
@@ -155,7 +161,7 @@ list_servers()
 if [ "${subcommand}" != "add" ] && [ "${subcommand}" != "rm" ] && [ "${subcommand}" != "list" ]; then
   echo "USAGE:"
   echo ""
-  echo "  ${COLOR_LIGHT_BLUE}db server add (server alias) (ssh) (hostname) (username) (password) (database)${COLOR_NC}"
+  echo "  ${COLOR_LIGHT_BLUE}db server add (server alias) (ssh) (hostname) (port) (username) (password) (database)${COLOR_NC}"
   echo ""
   echo "      Adds a server to the repository. All parameters are optional."
   echo ""

--- a/bin/drivers/mysql/connectors/ssh/load
+++ b/bin/drivers/mysql/connectors/ssh/load
@@ -12,6 +12,7 @@ restore_table() {
   _user=$(printf %q $(cat "${_credentials}" | grep "^user" | cut -d '=' -f 2 | xargs))
   _pass=$(printf %q $(cat "${_credentials}" | grep "^password" | cut -d '=' -f 2 | xargs))
   _host=$(printf %q $(cat "${_credentials}" | grep "^host" | cut -d '=' -f 2 | xargs))
+  _port=$(printf %q $(cat "${_credentials}" | grep "^port" | cut -d '=' -f 2 | xargs))
   _database=$(cat "${_db_file}")
 
   extract="${bin}/drivers/mysql/vendor/extract_sql/extract_sql.pl"
@@ -19,7 +20,7 @@ restore_table() {
   file "${file}" | grep gzip > /dev/null
   is_gzip="${?}"
 
-  cmd="mysql --user='${_user}' --host='${_host}' --password='${_pass}' ${_database}"
+  cmd="mysql --user='${_user}' --host='${_host}' --port='${_port}' --password='${_pass}' ${_database}"
 
   if [ "${is_gzip}" -eq 0 ]; then
     # this is a gzipped file
@@ -42,12 +43,13 @@ restore_snapshot() {
   _user=$(printf %q $(cat "${_credentials}" | grep "^user" | cut -d '=' -f 2 | xargs))
   _pass=$(printf %q $(cat "${_credentials}" | grep "^password" | cut -d '=' -f 2 | xargs))
   _host=$(printf %q $(cat "${_credentials}" | grep "^host" | cut -d '=' -f 2 | xargs))
+  _port=$(printf %q $(cat "${_credentials}" | grep "^port" | cut -d '=' -f 2 | xargs))
   _database=$(cat "${_db_file}")
 
   file "${file}" | grep gzip > /dev/null
   is_gzip="${?}"
 
-  cmd="mysql --user='${_user}' --host='${_host}' --password='${_pass}' ${_database}"
+  cmd="mysql --user='${_user}' --host='${_host}' --port='${_port}' --password='${_pass}' ${_database}"
 
   if [ "${is_gzip}" -eq 0 ]; then
     # this is a gzipped file

--- a/bin/drivers/mysql/connectors/ssh/run
+++ b/bin/drivers/mysql/connectors/ssh/run
@@ -9,7 +9,8 @@ run_sql() {
   _user=$(cat "${connection_config}" | grep "^user" | cut -d '=' -f 2 | xargs)
   _pass=$(cat "${connection_config}" | grep "^password" | cut -d '=' -f 2 | xargs)
   _host=$(cat "${connection_config}" | grep "^host" | cut -d '=' -f 2 | xargs)
-  output=$(ssh ${where} "echo \"$sql\" | mysql --user=\"$_user\" --host=\"$_host\" --password=\"$_pass\" $database --skip-column-names ")
+  _port=$(cat "${connection_config}" | grep "^port" | cut -d '=' -f 2 | xargs)
+
+  output=$(ssh ${where} "echo \"$sql\" | mysql --user=\"$_user\" --host=\"$_host\" --port=\"${_port}\" --password=\"$_pass\" $database --skip-column-names ")
   code=${?}
 }
-

--- a/bin/drivers/mysql/connectors/ssh/save
+++ b/bin/drivers/mysql/connectors/ssh/save
@@ -10,8 +10,9 @@ where=$(cat "${ssh_config}")
 _user=$(printf %q $(cat "${connection_config}" | grep "^user" | cut -d '=' -f 2 | xargs))
 _pass=$(printf %q $(cat "${connection_config}" | grep "^password" | cut -d '=' -f 2 | xargs))
 _host=$(printf %q $(cat "${connection_config}" | grep "^host" | cut -d '=' -f 2 | xargs))
+_port=$(printf %q $(cat "${connection_config}" | grep "^port" | cut -d '=' -f 2 | xargs))
 
-cmd="mysqldump --opt -B --add-drop-database --skip-extended-insert --user='${_user}' --host='${_host}' --password='${_pass}' ${database} | gzip"
+cmd="mysqldump --opt -B --add-drop-database --skip-extended-insert --user='${_user}' --host='${_host}' --port='${_port}' --password='${_pass}' ${database} | gzip"
 
 ssh ${where} "nice -n 19 sh -c '${cmd}'" > "${file}"
 

--- a/bin/drivers/mysql/connectors/ssh/test
+++ b/bin/drivers/mysql/connectors/ssh/test
@@ -8,7 +8,9 @@ where=$(cat "${ssh_config}")
 _user=$(cat "${connection_config}" | grep "^user" | cut -d '=' -f 2 | xargs)
 _pass=$(cat "${connection_config}" | grep "^password" | cut -d '=' -f 2 | xargs)
 _host=$(cat "${connection_config}" | grep "^host" | cut -d '=' -f 2 | xargs)
-ssh ${where} "mysql --user=\"$_user\" --host=\"$_host\" --password=\"$_pass\" -e\"quit\" $database"
+_port=$(cat "${connection_config}" | grep "^port" | cut -d '=' -f 2 | xargs)
+
+ssh ${where} "mysql --user=\"$_user\" --host=\"$_host\" --port=\"${_port}\" --password=\"$_pass\" -e\"quit\" $database"
 code=${?}
 
 if [ "${code}" -eq 127 ]; then

--- a/bin/include/vars
+++ b/bin/include/vars
@@ -11,7 +11,7 @@ if [ -f "${repository}/databasetype" ]; then
   databasetype=$(cat "${repository}/databasetype")
 fi
 
-config="${repository}/${identifier}/config/"
+config="${repository}/${identifier}/config"
 database_file="${config}/database"
 
 database=""


### PR DESCRIPTION
A quick change to enable setting a custom port during `db init` setup and use it when connecting over ssh.